### PR TITLE
Bells and Windows

### DIFF
--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -6231,6 +6231,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "dtQ" = (
@@ -6743,9 +6744,11 @@
 /area/station/engineering/supermatter/room)
 "dHz" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	name = "Brig Desk";
-	req_access = list("security")
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Outer Window"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -6757,6 +6760,11 @@
 	},
 /obj/item/pen{
 	pixel_x = -3
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -14251,6 +14259,7 @@
 	req_access = list("science")
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/lab)
 "hzf" = (
@@ -15899,6 +15908,16 @@
 "ivt" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
+"ivM" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/plating,
+/area/station/service/kitchen)
 "ivQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21246,15 +21265,21 @@
 /area/station/maintenance/port/fore)
 "lpG" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/left/directional/west{
 	base_state = "right";
+	dir = 2;
 	icon_state = "right";
-	name = "Brig Desk";
-	req_access = list("security")
+	name = "Reception Window"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
 	name = "Security Shutters"
+	},
+/obj/structure/desk_bell,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -21488,6 +21513,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "lwW" = (
@@ -26037,6 +26063,7 @@
 	id = "pharmacyshutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "nMe" = (
@@ -29304,6 +29331,7 @@
 	req_access = list("robotics")
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "psP" = (
@@ -32621,6 +32649,7 @@
 	name = "Privacy Shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "qTx" = (
@@ -38744,6 +38773,7 @@
 	req_access = list("shipping")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "tYc" = (
@@ -41717,6 +41747,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "vvk" = (
@@ -43527,6 +43558,7 @@
 	req_access = list("plumbing")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "wmw" = (
@@ -44870,6 +44902,7 @@
 	req_access = list("hydroponics")
 	},
 /obj/item/reagent_containers/glass/bucket,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "wRv" = (
@@ -81721,7 +81754,7 @@ mda
 pVg
 jrr
 gyi
-mgM
+ivM
 ssA
 pRy
 pZy

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -19010,9 +19010,11 @@
 /area/station/hallway/primary/fore)
 "kho" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	name = "Brig Desk";
-	req_access = list("security")
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Outer Window"
 	},
 /obj/item/paper_bin{
 	pixel_y = 4
@@ -19022,6 +19024,11 @@
 	name = "Security Shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access = list("armory")
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "khB" = (
@@ -20600,10 +20607,10 @@
 /area/station/medical/medbay/central)
 "laZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
-	name = "Brig Desk";
-	req_access = list("security")
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -20611,6 +20618,13 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/structure/desk_bell,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	dir = 2;
+	icon_state = "right";
+	name = "Reception Window"
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "lbo" = (
@@ -21311,6 +21325,7 @@
 	name = "HoP Reception Window";
 	req_access = list("hop")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "lsl" = (
@@ -21724,6 +21739,7 @@
 	req_access = list("shipping")
 	},
 /obj/item/clipboard,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "lBH" = (
@@ -26985,6 +27001,7 @@
 	name = "Atmospherics Desk";
 	req_one_access = list("atmospherics","engineering")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "ooH" = (
@@ -27077,6 +27094,7 @@
 "oqS" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/service/bar)
 "oqY" = (
@@ -27629,6 +27647,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "oDN" = (
@@ -29521,6 +29540,7 @@
 	req_access = list("cargo")
 	},
 /obj/item/storage/fancy/donut_box,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "pCd" = (
@@ -32014,6 +32034,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/folder/white,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "qRr" = (
@@ -34704,9 +34725,11 @@
 /area/station/ai_monitored/command/nuke_storage)
 "skd" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/east{
-	name = "Brig Desk";
-	req_access = list("brig")
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Outer Window"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -34714,6 +34737,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access = list("armory")
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "skk" = (
@@ -35135,6 +35163,7 @@
 	req_access = list("hydroponics")
 	},
 /obj/item/reagent_containers/glass/bucket,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "sxA" = (
@@ -36239,6 +36268,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/explab)
 "tfR" = (
@@ -41116,6 +41146,7 @@
 	id = "kitchen";
 	name = "Kitchen Shutters"
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "vva" = (
@@ -41349,6 +41380,7 @@
 	req_access = list("pharmacy")
 	},
 /obj/item/paper/crumpled,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "vAc" = (

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -10919,6 +10919,7 @@
 	req_access = list("hydroponics")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "eAT" = (
@@ -11315,6 +11316,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/effect/spawner/random/bureaucracy/pen,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "eKX" = (
@@ -13032,6 +13034,7 @@
 	req_access = list("mining_station")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fBR" = (
@@ -17599,6 +17602,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"hDE" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "hDP" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
@@ -18699,6 +18710,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacyshutters"
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "idJ" = (
@@ -21061,6 +21073,7 @@
 	name = "Psychology Office";
 	req_access = list("psychology")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/medical/psychology)
 "jeX" = (
@@ -21320,6 +21333,7 @@
 	name = "Robotics Desk";
 	req_access = list("robotics")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/robotics)
 "jlK" = (
@@ -24412,14 +24426,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/tcommsat/server/upper)
-"kCc" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "kCe" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/purple,
@@ -30088,9 +30094,11 @@
 /area/station/medical/medbay)
 "mUR" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	name = "Brig Desk";
-	req_access = list("security")
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Outer Window"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -30102,6 +30110,11 @@
 	},
 /obj/item/pen{
 	pixel_x = -3
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -33901,6 +33914,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"oBb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/plating,
+/area/station/service/kitchen)
 "oBe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/meter,
@@ -35210,10 +35233,6 @@
 /area/station/tcommsat/computer)
 "pdO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Engineering Desk";
-	req_access = list("construction")
-	},
 /obj/item/paper_bin{
 	pixel_x = -5;
 	pixel_y = 4
@@ -35223,6 +35242,11 @@
 	pixel_y = 7
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/window/left/directional/south{
+	name = "Engineering Desk";
+	req_access = list("construction")
+	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "pdP" = (
@@ -36140,6 +36164,7 @@
 	req_access = list("science")
 	},
 /obj/structure/table/reinforced,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/lab)
 "pCf" = (
@@ -39490,6 +39515,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "qWn" = (
@@ -40744,6 +40770,7 @@
 	req_access = list("shipping")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "ryM" = (
@@ -55226,15 +55253,21 @@
 /area/station/maintenance/port/fore)
 "xKB" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/left/directional/west{
 	base_state = "right";
+	dir = 2;
 	icon_state = "right";
-	name = "Brig Desk";
-	req_access = list("security")
+	name = "Reception Window"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
 	name = "Security Shutters"
+	},
+/obj/structure/desk_bell,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -90565,7 +90598,7 @@ fVi
 lVe
 eUe
 hOa
-kCc
+cjf
 iMD
 xQd
 olL
@@ -95675,7 +95708,7 @@ gbM
 mva
 pOL
 llC
-uFO
+hDE
 rQl
 nQi
 kya
@@ -100039,7 +100072,7 @@ vSZ
 xYU
 kXZ
 jWb
-lVk
+oBb
 vYd
 wlC
 tPe

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -9284,6 +9284,7 @@
 	name = "Privacy Shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "dgI" = (
@@ -9443,6 +9444,7 @@
 	name = "Delivery Desk";
 	req_access = list("shipping")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "dkZ" = (
@@ -13964,6 +13966,7 @@
 	name = "Robotics Lab Shutters"
 	},
 /obj/item/folder/white,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "fpN" = (
@@ -26224,6 +26227,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/item/pen,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/lab)
 "mgu" = (
@@ -26425,6 +26429,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "mjV" = (
@@ -29353,6 +29358,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"nXM" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "nXQ" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -30053,6 +30066,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/start/hangover,
 /obj/structure/cable,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "otR" = (
@@ -31834,6 +31848,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "pww" = (
@@ -33799,6 +33814,7 @@
 	req_one_access = list("atmospherics","engineering")
 	},
 /obj/structure/table/reinforced,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "qAc" = (
@@ -33976,6 +33992,7 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/table/reinforced,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "qHO" = (
@@ -36974,6 +36991,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"stj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/desk_bell,
+/turf/open/floor/iron,
+/area/station/service/kitchen)
 "stp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -41866,6 +41893,7 @@
 	name = "Brig Front Blast Door"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/security/brig)
 "vgM" = (
@@ -77372,7 +77400,7 @@ wnQ
 nWs
 uMZ
 buP
-qck
+stj
 ydf
 fYE
 hQX
@@ -80763,7 +80791,7 @@ wTx
 cDJ
 oZN
 lfE
-jtE
+nXM
 gRG
 gRG
 qVO

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1130,6 +1130,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aeq" = (
@@ -1938,12 +1939,19 @@
 /area/station/medical/chemistry)
 "agZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	name = "Brig Desk";
-	req_access = list("security")
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Outer Window"
 	},
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access = list("armory")
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aha" = (
@@ -6834,12 +6842,10 @@
 /area/station/security/brig)
 "awO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
-	base_state = "right";
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
-	icon_state = "right";
-	name = "Brig Desk";
-	req_access = list("brig")
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -6872,14 +6878,13 @@
 	id = "Secure Gate";
 	name = "Brig Shutters"
 	},
-/obj/machinery/door/window/left/directional/south{
-	base_state = "right";
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
-	icon_state = "right";
-	name = "Brig Desk";
-	req_access = list("brig")
+	name = "Brig Control Desk";
+	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "awR" = (
@@ -9734,6 +9739,7 @@
 	id = "hop";
 	name = "Privacy Shutters"
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "aFC" = (
@@ -16324,6 +16330,7 @@
 	req_access = list("hydroponics")
 	},
 /obj/item/food/monkeycube,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bce" = (
@@ -18233,6 +18240,7 @@
 	id = "robotics";
 	name = "Robotics Lab Shutters"
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "bjn" = (
@@ -19893,6 +19901,7 @@
 	name = "Research Shutters"
 	},
 /obj/item/folder/white,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/research)
 "bqd" = (
@@ -23536,6 +23545,7 @@
 	name = "Security Desk";
 	req_access = list("security")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
 "bDI" = (
@@ -26501,6 +26511,7 @@
 	name = "Atmospherics Desk";
 	req_access = list("atmospherics")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bOO" = (
@@ -34556,6 +34567,7 @@
 	name = "Cargo Desk";
 	req_access = list("shipping")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "cxK" = (
@@ -40715,6 +40727,7 @@
 	name = "Medbay Front Desk";
 	req_access = list("medical")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "lya" = (
@@ -41902,6 +41915,7 @@
 	},
 /obj/item/paper_bin/carbon,
 /obj/item/pen,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nyB" = (
@@ -41932,6 +41946,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nAy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenshutters";
+	name = "Kitchen Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/iron/dark,
+/area/station/service/kitchen)
 "nBt" = (
 /obj/structure/rack,
 /obj/item/storage/box/shipping,
@@ -45661,6 +45688,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"sUy" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "sUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -79956,7 +79991,7 @@ aRN
 aYX
 bad
 bbl
-bbl
+nAy
 bbl
 sbI
 aRN
@@ -82008,7 +82043,7 @@ aKT
 aVi
 bah
 aXh
-aZd
+sUy
 bag
 beB
 abc

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -2370,6 +2370,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron/white,
 /area/station/engineering/gravity_generator)
 "aiF" = (
@@ -4053,6 +4054,7 @@
 	name = "HoP Queue Shutters"
 	},
 /obj/effect/spawner/random/entertainment/wallet_storage,
+/obj/structure/desk_bell,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aoC" = (
@@ -7342,6 +7344,7 @@
 	pixel_y = 32
 	},
 /obj/structure/displaycase/forsale,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/chapel)
 "axp" = (
@@ -9593,6 +9596,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDr" = (
@@ -14888,6 +14892,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"dTf" = (
+/obj/structure/table,
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("robotics")
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/desk_bell,
+/turf/open/floor/iron/smooth,
+/area/station/service/hydroponics/garden)
 "dTh" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -37593,6 +37607,7 @@
 "uFt" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/gun/ballistic/revolver/russian,
+/obj/structure/desk_bell,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "uFA" = (
@@ -75853,7 +75868,7 @@ aal
 tOO
 anC
 mhQ
-mhQ
+dTf
 axs
 anC
 anC


### PR DESCRIPTION
Adds new bells to relevant locations on our maps
Updated outside security windows on Cube, Echo, IceCube, and Pubby to use brigdoor type windows Modified IceCube's engineering lobby windows slightly (opens the new bell to the public)
